### PR TITLE
[5.28] PEP 639 compliant licensing meta data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog
 =========
 
 ## Next Release
+* Update licensing meta data to be PEP 639 compliant.
+
+
+## Next Release
 * Moved repository:  
   from https://github.com/neo4j-drivers/neo4j-python-driver-rust-ext  
   to https://github.com/neo4j/neo4j-python-driver-rust-ext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,11 @@
 [project]
 name = "neo4j-rust-ext"
 description = "Rust Extensions for a Faster Neo4j Bolt Driver for Python"
-license = {text = "Apache License, Version 2.0"}
+license = "Apache-2.0"
+license-files = [
+    "LICENSE*.txt",
+    "NOTICE*.txt",
+]
 readme = "README.md"
 authors = [
     {name = "Neo4j, Inc.", email = "drivers@neo4j.com"},
@@ -29,7 +33,6 @@ keywords = ["neo4j", "graph", "database"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -58,7 +61,7 @@ pandas = ["neo4j[pandas]"]
 pyarrow = ["neo4j[pyarrow]"]
 
 [build-system]
-requires = ["maturin ~= 1.8.3"]
+requires = ["maturin ~= 1.9.0"]
 build-backend = "maturin"
 
 [tool.maturin]


### PR DESCRIPTION
Back-port of https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/38