### PR TITLE
[5.28] pre-commit: use local rust steps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,22 @@ repos:
           - batch
       - id: trailing-whitespace
         args: [ --markdown-linebreak-ext=md ]
-  - repo: https://github.com/doublify/pre-commit-rust
-    rev: v1.0
+  - repo: local
     hooks:
-      - id: fmt
-      - id: cargo-check
-      - id: clippy
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt
+        language: system
+        types: [rust]
+        pass_filenames: false
+  - repo: local
+    hooks:
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-features --tests -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
   - repo: local
     hooks:
       - id: isort


### PR DESCRIPTION
Backport of https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/48