### PR TITLE
[5.28] Fix target_driver script producing suboptimal changelog file

### DIFF
--- a/bin/target_driver.sh
+++ b/bin/target_driver.sh
@@ -13,5 +13,6 @@ git pull origin "$version"
 cd ..
 cp driver/tests/unit/common/codec/packstream/v1/test_packstream.py tests/v1/from_driver/test_packstream.py
 
-towncrier create -c "Target driver version ${version}<ISSUES_LIST>." "+.feature"
+towncrier create -c "Target driver version ${version}<ISSUES_LIST>.
+" "+.feature.md"
 echo "=== Please rename the changelog file to match the PR number. ==="


### PR DESCRIPTION
Back port of https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/55