### PR TITLE
Fix PR link in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,9 @@ Changelog
 ## [5.28.2.1](https://github.com/neo4j/neo4j-python-driver-rust-ext/tree/5.28.2.1) (2025-08-15)
 ***
 ### **🔧️ Fixes**
-* Fix decoding of map keys of certain sizes ([#59]).
+* Fix decoding of map keys of certain sizes ([#60]).
 
-[#59]: https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/59
+[#60]: https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/60
 
 
 ## [5.28.2.0](https://github.com/neo4j/neo4j-python-driver-rust-ext/tree/5.28.2.0) (2025-07-30)


### PR DESCRIPTION
See also https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/64