### PR TITLE
Minor improvement of internal error message

### DIFF
--- a/changelog.d/74.dev.md
+++ b/changelog.d/74.dev.md
@@ -1,0 +1,1 @@
+Improve details of internal error message<ISSUES_LIST>.

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -38,9 +38,9 @@ fn swap_endian<'py>(
     let bytes = &data.as_bytes();
     let len = bytes.len();
     if len % type_size != 0 {
-        return Err(PyErr::new::<PyValueError, _>(
-            "Data length not a multiple of type_size",
-        ));
+        return Err(PyErr::new::<PyValueError, _>(format!(
+            "Data length {len} not a multiple of type_size {type_size}",
+        )));
     }
 
     PyBytes::new_with(py, bytes.len(), |out| {


### PR DESCRIPTION
This error path shouldn't ever be hit if the driver is working as intended. This change might make debugging while developing the driver slightly easier in the future.

Initial discussion:
https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/70#discussion_r2503626096