### PR TITLE
[5.28] Add .semgrepignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ var/
 include/
 man/
 venv/
+/.venv*/
+/venv*/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,5 @@
+:include .gitignore
+
+/driver/
+/testkit/
+/tests/


### PR DESCRIPTION
Closes: DRIVERS-227

Back port of https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/76