### PR TITLE
[5.28] Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "portable-atomic"
@@ -71,11 +65,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -89,19 +82,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -109,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -121,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ name = "neo4j_rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.24.2"
+pyo3 = "0.27.2"

--- a/changelog.d/79.improve.md
+++ b/changelog.d/79.improve.md
@@ -1,0 +1,4 @@
+Update dependencies<ISSUES_LIST>:
+
+ * Update `maturin` (Python package builder) from `~= 1.9.1` to `~= 1.11.5`.
+ * Update `PyO3` from `0.24.2` to `0.27.2`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ pandas = ["neo4j[pandas]"]
 pyarrow = ["neo4j[pyarrow]"]
 
 [build-system]
-requires = ["maturin ~= 1.9.1"]
+requires = ["maturin ~= 1.11.5"]
 build-backend = "maturin"
 
 [tool.maturin]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ fn register_package(m: &Bound<PyModule>, name: &str) -> PyResult<()> {
 pub struct Structure {
     tag: u8,
     #[pyo3(get)]
-    fields: Vec<PyObject>,
+    fields: Vec<Py<PyAny>>,
 }
 
 #[pymethods]
@@ -64,7 +64,7 @@ impl Structure {
     #[new]
     #[pyo3(signature = (tag, *fields))]
     #[pyo3(text_signature = "(tag, *fields)")]
-    fn new(tag: &[u8], fields: Vec<PyObject>) -> PyResult<Self> {
+    fn new(tag: &[u8], fields: Vec<Py<PyAny>>) -> PyResult<Self> {
         if tag.len() != 1 {
             return Err(PyErr::new::<PyValueError, _>("tag must be a single byte"));
         }
@@ -99,7 +99,7 @@ impl Structure {
         Ok(true)
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<Py<PyAny>> {
         Ok(match op {
             CompareOp::Eq => self.eq(other, py)?.into_py_any(py)?,
             CompareOp::Ne => (!self.eq(other, py)?).into_py_any(py)?,

--- a/src/v1/pack.rs
+++ b/src/v1/pack.rs
@@ -14,11 +14,11 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 
-use pyo3::exceptions::{PyImportError, PyOverflowError, PyTypeError, PyValueError};
+use pyo3::exceptions::{PyOverflowError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::sync::GILOnceCell;
+use pyo3::sync::OnceLockExt;
 use pyo3::types::{PyBytes, PyDict, PyString, PyType};
 use pyo3::{intern, IntoPyObjectExt};
 
@@ -31,14 +31,14 @@ use crate::Structure;
 
 #[derive(Debug)]
 struct TypeMappings {
-    none_values: Vec<PyObject>,
-    true_values: Vec<PyObject>,
-    false_values: Vec<PyObject>,
-    int_types: PyObject,
-    float_types: PyObject,
-    sequence_types: PyObject,
-    mapping_types: PyObject,
-    bytes_types: PyObject,
+    none_values: Vec<Py<PyAny>>,
+    true_values: Vec<Py<PyAny>>,
+    false_values: Vec<Py<PyAny>>,
+    int_types: Py<PyAny>,
+    float_types: Py<PyAny>,
+    sequence_types: Py<PyAny>,
+    mapping_types: Py<PyAny>,
+    bytes_types: Py<PyAny>,
 }
 
 impl TypeMappings {
@@ -97,29 +97,19 @@ impl TypeMappings {
     }
 }
 
-static TYPE_MAPPINGS: GILOnceCell<PyResult<TypeMappings>> = GILOnceCell::new();
-static TYPE_MAPPINGS_INIT: AtomicBool = AtomicBool::new(false);
+static TYPE_MAPPINGS: OnceLock<PyResult<TypeMappings>> = OnceLock::new();
 
 fn get_type_mappings(py: Python<'_>) -> PyResult<&'static TypeMappings> {
-    let mappings = TYPE_MAPPINGS.get_or_try_init(py, || {
-        fn init(py: Python<'_>) -> PyResult<TypeMappings> {
-            let locals = PyDict::new(py);
-            py.run(
-                c"from neo4j._codec.packstream.v1.types import *",
-                None,
-                Some(&locals),
-            )?;
-            TypeMappings::new(&locals)
-        }
-
-        if TYPE_MAPPINGS_INIT.swap(true, Ordering::SeqCst) {
-            return Err(PyErr::new::<PyImportError, _>(
-                "Cannot call _rust.pack while loading `neo4j._codec.packstream.v1.types`",
-            ));
-        }
-        Ok(init(py))
+    let mappings = TYPE_MAPPINGS.get_or_init_py_attached(py, || {
+        let locals = PyDict::new(py);
+        py.run(
+            c"from neo4j._codec.packstream.v1.types import *",
+            None,
+            Some(&locals),
+        )?;
+        TypeMappings::new(&locals)
     });
-    mappings?.as_ref().map_err(|e| e.clone_ref(py))
+    mappings.as_ref().map_err(|e| e.clone_ref(py))
 }
 
 #[pyfunction]
@@ -241,7 +231,7 @@ impl<'a> PackStreamEncoder<'a> {
     fn write_exact_value(
         &mut self,
         value: &Bound<PyAny>,
-        values: &[PyObject],
+        values: &[Py<PyAny>],
         bytes: &[u8],
     ) -> PyResult<bool> {
         for v in values {

--- a/src/v1/unpack.rs
+++ b/src/v1/unpack.rs
@@ -32,7 +32,7 @@ pub(super) fn unpack(
     bytes: Bound<PyByteArray>,
     idx: usize,
     hydration_hooks: Option<Bound<PyDict>>,
-) -> PyResult<(PyObject, usize)> {
+) -> PyResult<(Py<PyAny>, usize)> {
     let py = bytes.py();
     let mut decoder = PackStreamDecoder::new(py, bytes, idx, hydration_hooks);
     let result = decoder.read()?;
@@ -61,12 +61,12 @@ impl<'a> PackStreamDecoder<'a> {
         }
     }
 
-    fn read(&mut self) -> PyResult<PyObject> {
+    fn read(&mut self) -> PyResult<Py<PyAny>> {
         let marker = self.read_byte()?;
         self.read_value(marker)
     }
 
-    fn read_value(&mut self, marker: u8) -> PyResult<PyObject> {
+    fn read_value(&mut self, marker: u8) -> PyResult<Py<PyAny>> {
         let high_nibble = marker & 0xF0;
 
         Ok(match marker {
@@ -141,7 +141,7 @@ impl<'a> PackStreamDecoder<'a> {
         })
     }
 
-    fn read_list(&mut self, length: usize) -> PyResult<PyObject> {
+    fn read_list(&mut self, length: usize) -> PyResult<Py<PyAny>> {
         if length == 0 {
             return Ok(PyList::empty(self.py).into_any().unbind());
         }
@@ -152,7 +152,7 @@ impl<'a> PackStreamDecoder<'a> {
         items.into_py_any(self.py)
     }
 
-    fn read_string(&mut self, length: usize) -> PyResult<PyObject> {
+    fn read_string(&mut self, length: usize) -> PyResult<Py<PyAny>> {
         if length == 0 {
             return "".into_py_any(self.py);
         }
@@ -174,11 +174,11 @@ impl<'a> PackStreamDecoder<'a> {
         data.into_py_any(self.py)
     }
 
-    fn read_map(&mut self, length: usize) -> PyResult<PyObject> {
+    fn read_map(&mut self, length: usize) -> PyResult<Py<PyAny>> {
         if length == 0 {
             return Ok(PyDict::new(self.py).into_any().unbind());
         }
-        let mut key_value_pairs: Vec<(PyObject, PyObject)> = Vec::with_capacity(length);
+        let mut key_value_pairs: Vec<(Py<PyAny>, Py<PyAny>)> = Vec::with_capacity(length);
         for _ in 0..length {
             let len = self.read_string_length()?;
             let key = self.read_string(len)?;
@@ -188,7 +188,7 @@ impl<'a> PackStreamDecoder<'a> {
         Ok(key_value_pairs.into_py_dict(self.py)?.into())
     }
 
-    fn read_bytes(&mut self, length: usize) -> PyResult<PyObject> {
+    fn read_bytes(&mut self, length: usize) -> PyResult<Py<PyAny>> {
         if length == 0 {
             return Ok(PyBytes::new(self.py, &[]).into_any().unbind());
         }
@@ -208,7 +208,7 @@ impl<'a> PackStreamDecoder<'a> {
         Ok(PyBytes::new(self.py, &data).into_any().unbind())
     }
 
-    fn read_struct(&mut self, length: usize) -> PyResult<PyObject> {
+    fn read_struct(&mut self, length: usize) -> PyResult<Py<PyAny>> {
         let tag = self.read_byte()?;
         let mut fields = Vec::with_capacity(length);
         for _ in 0..length {


### PR DESCRIPTION
Backports some of the changes from:
 * https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/66
 * https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/71
 * https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/52 (since `GILOnceCell` has been deprecated in PyO3 0.26.0, let's backport to whole simplification to avoid the deprecation.)