### PR TITLE
[5.28] Target driver version 5.28.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Changelog
 
 <!-- towncrier release notes start -->
 
+## [5.28.3.0](https://github.com/neo4j/neo4j-python-driver-rust-ext/tree/5.28.3.0) (2026-01-12)
+***
+### **⭐️ New Features**
+* Target driver version 5.28.3 ([#80]).
+
+[#80]: https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/80
+
+### **👏️ Improvements**
+* Update dependencies ([#79]):
+  * Update `maturin` (Python package builder) from `~= 1.9.1` to `~= 1.11.5`.
+  * Update `PyO3` from `0.24.2` to `0.27.2`.
+
+[#79]: https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/79
+
+
 ## [5.28.2.1](https://github.com/neo4j/neo4j-python-driver-rust-ext/tree/5.28.2.1) (2025-08-15)
 ***
 ### **🔧️ Fixes**

--- a/changelog.d/79.improve.md
+++ b/changelog.d/79.improve.md
@@ -1,4 +1,0 @@
-Update dependencies<ISSUES_LIST>:
-
- * Update `maturin` (Python package builder) from `~= 1.9.1` to `~= 1.11.5`.
- * Update `PyO3` from `0.24.2` to `0.27.2`.

--- a/changelog.d/80.feature.md
+++ b/changelog.d/80.feature.md
@@ -1,0 +1,1 @@
+Target driver version 5.28.3<ISSUES_LIST>.

--- a/changelog.d/80.feature.md
+++ b/changelog.d/80.feature.md
@@ -1,1 +1,0 @@
-Target driver version 5.28.3<ISSUES_LIST>.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ authors = [
     {name = "Neo4j, Inc.", email = "drivers@neo4j.com"},
 ]
 dependencies = [
-    "neo4j == 5.28.2"
+    "neo4j == 5.28.3"
 ]
 requires-python = ">=3.7"
 keywords = ["neo4j", "graph", "database"]
@@ -45,7 +45,7 @@ classifiers = [
     "Topic :: Database",
     "Topic :: Software Development",
 ]
-version = "5.28.2.1"
+version = "5.28.3.0"
 
 [project.urls]
 Homepage = "https://neo4j.com/"
@@ -83,7 +83,7 @@ exclude = [
 
 [tool.towncrier]
 directory = "changelog.d"
-version = "5.28.2.1"
+version = "5.28.3.0"
 filename = "CHANGELOG.md"
 title_format = "## [{version}](https://github.com/neo4j/neo4j-python-driver-rust-ext/tree/{version}) ({project_date})\n***"
 issue_format = "[#{issue}]: https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/{issue}"

--- a/tests/v1/from_driver/test_packstream.py
+++ b/tests/v1/from_driver/test_packstream.py
@@ -15,6 +15,7 @@
 
 
 import struct
+import sys
 from io import BytesIO
 from math import (
     isnan,
@@ -37,6 +38,11 @@ from neo4j._codec.packstream.v1 import (
 
 standard_ascii = [chr(i) for i in range(128)]
 not_ascii = "♥O◘♦♥O◘♦"
+SKIP_PANDAS_INT_AS_INT64 = (
+    pd.Series([], dtype=int).dtype.itemsize < 8
+    and sys.version_info < (3, 9)
+    and sys.platform == "win32"
+)
 
 
 @pytest.fixture
@@ -289,7 +295,13 @@ class TestPackStream:
     @pytest.mark.parametrize(
         "dtype",
         (
-            int,
+            pytest.param(
+                int,
+                marks=pytest.mark.skipif(
+                    SKIP_PANDAS_INT_AS_INT64,
+                    reason="Legacy pandas treating int as int32",
+                ),
+            ),
             pd.Int64Dtype(),
             pd.UInt64Dtype(),
             np.int64,
@@ -317,7 +329,13 @@ class TestPackStream:
     @pytest.mark.parametrize(
         "dtype",
         (
-            int,
+            pytest.param(
+                int,
+                marks=pytest.mark.skipif(
+                    SKIP_PANDAS_INT_AS_INT64,
+                    reason="Legacy pandas treating int as int32",
+                ),
+            ),
             pd.Int64Dtype(),
             np.int64,
             np.longlong,


### PR DESCRIPTION
Depends on (i.e., merge this first then rebase):
 * https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/79